### PR TITLE
Add registration options

### DIFF
--- a/src/api/fetchRegistrationOptions.ts
+++ b/src/api/fetchRegistrationOptions.ts
@@ -1,0 +1,24 @@
+import { ResponseRegistrationOptionsType } from '../types/RegistrationOption';
+
+async function fetchRegistrationOptions(): Promise<ResponseRegistrationOptionsType | null> {
+  try {
+    const response = await fetch(`${import.meta.env.VITE_SERVER_URL}/api/registration-options`, {
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const options = (await response.json()) as { data: ResponseRegistrationOptionsType };
+    return options.data;
+  } catch (error) {
+    console.error('Error fetching nonce:', error);
+    return null;
+  }
+}
+
+export default fetchRegistrationOptions;

--- a/src/api/fetchRegistrationOptions.ts
+++ b/src/api/fetchRegistrationOptions.ts
@@ -16,7 +16,7 @@ async function fetchRegistrationOptions(): Promise<ResponseRegistrationOptionsTy
     const options = (await response.json()) as { data: ResponseRegistrationOptionsType };
     return options.data;
   } catch (error) {
-    console.error('Error fetching nonce:', error);
+    console.error('Error fetching registration options:', error);
     return null;
   }
 }

--- a/src/api/postRegistration.ts
+++ b/src/api/postRegistration.ts
@@ -9,6 +9,7 @@ async function postRegistration({
   proposalAbstract,
   status,
   groupIds,
+  registrationOptionIds,
 }: PostProposalType) {
   try {
     const response = await fetch(`${import.meta.env.VITE_SERVER_URL}/api/registrations`, {
@@ -26,6 +27,7 @@ async function postRegistration({
         proposalAbstract,
         status,
         groupIds,
+        registrationOptionIds,
       }),
     });
 

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -226,9 +226,7 @@ function Register() {
               {registrationOptions &&
                 Object.entries(registrationOptions).map(([category, options]) => (
                   <FlexColumn key={category} $gap="0.5rem">
-                    <Label htmlFor={category} required>
-                      {category}
-                    </Label>
+                    <Label htmlFor={category}>{category}</Label>
                     <Select
                       id={`registrationOptions.${category}`}
                       name={`registrationOptions.${category}`}

--- a/src/types/ProposalType.ts
+++ b/src/types/ProposalType.ts
@@ -6,6 +6,21 @@ type GroupsUsers = {
   groupId: string;
 };
 
+type RegistrationOptions = {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  userId: string;
+  registrationOptionId: string;
+  registrationOption: {
+    id: string;
+    name: string;
+    createdAt: Date;
+    updatedAt: Date;
+    category: string;
+  };
+};
+
 export type ResponseProposalType = {
   userId: string;
   email?: string | undefined;
@@ -15,6 +30,7 @@ export type ResponseProposalType = {
   proposalAbstract?: string | undefined;
   status?: 'DRAFT' | 'PUBLISHED' | undefined;
   groups: GroupsUsers[];
+  registrationOptions: RegistrationOptions[];
 };
 
 export type PostProposalType = {
@@ -25,5 +41,6 @@ export type PostProposalType = {
   proposalTitle: string;
   proposalAbstract?: string | undefined;
   status?: 'DRAFT' | 'PUBLISHED' | undefined;
-  groupIds: string[] | null;
+  groupIds: string[];
+  registrationOptionIds: string[];
 };

--- a/src/types/RegistrationOption.ts
+++ b/src/types/RegistrationOption.ts
@@ -1,0 +1,9 @@
+export type ResponseRegistrationOptionsType = {
+  [categoryName: string]: {
+    id: string;
+    name: string;
+    createdAt: Date;
+    updatedAt: Date;
+    category: string;
+  }[];
+};


### PR DESCRIPTION
blocked by https://github.com/lexicongovernance/forum-backend/pull/25
closes https://github.com/lexicongovernance/forum-frontend/issues/10

## overview
dynamically autocompletes and saves registrationOptions


### things not included in this pr
- validation on dynamic fields
- decouple some functionalities so it is easier to understand in the future
