### PR TITLE
Remove required flag from publications and mev contributions

### DIFF
--- a/packages/berlin/src/pages/Account.tsx
+++ b/packages/berlin/src/pages/Account.tsx
@@ -340,7 +340,7 @@ function AccountForm({
             />
           </FlexColumn>
           <FlexColumn $gap="0.5rem">
-            <Label $required>Publications</Label>
+            <Label >Publications</Label>
             {fieldsPublications.map((field, i) => (
               <FlexRow key={field.id}>
                 <Input
@@ -361,7 +361,7 @@ function AccountForm({
             />
           </FlexColumn>
           <FlexColumn $gap="0.5rem">
-            <Label $required>Contributions to MEV</Label>
+            <Label >Contributions to MEV</Label>
             {fieldsContributions.map((field, i) => (
               <FlexRow key={field.id}>
                 <Input


### PR DESCRIPTION
The PR removes the required flag from the `Label` for publication and mev contribution links. 