### PR TITLE
Modify data structure and onboarding rendering

### DIFF
--- a/packages/berlin/src/data/onboarding.ts
+++ b/packages/berlin/src/data/onboarding.ts
@@ -3,20 +3,24 @@ const onboarding = {
     {
       id: 0,
       title: `Ambitions & Trust Assumptions`,
-      body: `Our mechanisms (plural voting, peer prediction) require some social information (e.g., organizational affiliation, academic credentials) to work. Initially, this information will be stored in the community’s secure database (managed by Lexicon), and used solely for the purposes of calculating plurality scores and managing community attendance.`,
+      body: [
+        {
+          id: 0,
+          text: `Our mechanisms (plural voting, peer prediction) require some social information (e.g., organizational affiliation, academic credentials) to work. Initially, this information will be stored in the community’s secure database (managed by Lexicon), and used solely for the purposes of calculating plurality scores and managing community attendance.`,
+        },
+        {
+          id: 1,
+          text: `Our ambition is to add a ZKDF PCD (zero-knowledge data format proof-carrying data) to your Zupass, which will allow us to conduct experiments using zero-knowledge proofs and eliminate this information from our database. We welcome community participation in enhancing privacy.`,
+        },
+      ],
     },
     {
       id: 1,
-      title: `ZKDF PCDs`,
-      body: `Our ambition is to add a ZKDF PCD (zero-knowledge data format proof-carrying data) to your Zupass, which will allow us to conduct experiments using zero-knowledge proofs and eliminate this information from our database. We welcome community participation in enhancing privacy.`,
-    },
-    {
-      id: 2,
       title: `Forkability`,
       body: `Each member of the Plural Research Society who attends our community gathering will receive a credential represented as a PCD. This will enable anyone to invite members to future convenings with zero-knowledge verification.`,
     },
     {
-      id: 3,
+      id: 2,
       title: `Guiding Principles`,
       body: [
         {

--- a/packages/berlin/src/pages/Onboarding.tsx
+++ b/packages/berlin/src/pages/Onboarding.tsx
@@ -49,11 +49,11 @@ function Onboarding() {
 export default Onboarding;
 
 type BodyContentProps = {
-  content: string | { id: number; title: string; text: string }[];
+  content: string | { id: number; title?: string; text: string }[];
 };
 
 function BodyContent({ content }: BodyContentProps) {
-  if (Array.isArray(content)) {
+  if (Array.isArray(content) && content[0].title) {
     return (
       <ul>
         {content.map((item) => (
@@ -66,6 +66,16 @@ function BodyContent({ content }: BodyContentProps) {
           </li>
         ))}
       </ul>
+    );
+  }
+
+  if (Array.isArray(content)) {
+    return (
+      <FlexColumn $gap="1.5rem">
+        {content.map((item) => (
+          <Body key={item.id}>{item.text}</Body>
+        ))}
+      </FlexColumn>
     );
   }
 


### PR DESCRIPTION
## Closes: #161

## Evidence: 

![image](https://github.com/lexicongovernance/forum-frontend/assets/59750365/c51d9f21-e8e6-4e21-809b-c73d1d0bf732)

## Usage:
For onboarding slide with multiple texts:
```js
{
  id: 0,
  title: `Ambitions & Trust Assumptions`,
  body: [
    {
      id: 0,
      text: `Text one`,
    },
    {
      id: 1,
      text: `Text two`,
     },
  ],
},
```

For onboarding slide with bulleted items and bold subtitles:
```js
{
  id: 1,
  title: `Guiding Principles`,
  body: [
    {
      id: 0,
      title: `Title one`,
      text: `Text one`,
    },
    {
      id: 1,
      title: `Title one`,
      text: `Text two`,
     },
  ],
},
```