### PR TITLE
Fix credentail validation

### DIFF
--- a/packages/berlin/src/pages/Account.tsx
+++ b/packages/berlin/src/pages/Account.tsx
@@ -403,7 +403,7 @@ function AccountForm({
               />
             )}
           />
-          <Button type="submit" disabled={!isValid}>
+          <Button type="submit">
             Submit
           </Button>
         </FlexColumn>


### PR DESCRIPTION
This PR fixes an error that was fixed in https://github.com/lexicongovernance/forum-frontend/pull/149 but got re-introduced in https://github.com/lexicongovernance/forum-frontend/pull/152.

Basically, I changed the button element from `<Button type="submit" disabled={!isValid}>` to `<Button type="submit">Submit</Button>` again.