### PR TITLE
Fix display custom academic credentials 

### DIFF
--- a/packages/berlin/src/pages/Account.tsx
+++ b/packages/berlin/src/pages/Account.tsx
@@ -306,7 +306,7 @@ function AccountForm({
                       onBlur={field.onBlur}
                       value={field.value}
                       onOptionCreate={field.onChange}
-                      placeholder="Select or create credential"
+                      placeholder={field.value ? field.value : "Select or create credential"}
                       errors={[
                         errors.userAttributes?.credentialsGroup?.[i]?.credential?.message ?? '',
                       ]}


### PR DESCRIPTION
## Overview
This PR adds functionality to the Select component to dynamically display the selected credential instead of the placeholder text when data is available in `userAttributes.credentialsGroup.${i}.credential`.

Modified the Select component to conditionally render the selected value as the placeholder if it exists, instead of the default placeholder text.

