### PR TITLE
Add page reload for account in header

### DIFF
--- a/packages/berlin/src/components/header/Header.tsx
+++ b/packages/berlin/src/components/header/Header.tsx
@@ -57,6 +57,12 @@ function Header() {
 
   const [isBurgerMenuOpen, setIsBurgerMenuOpen] = useState(false);
 
+  // Define onClick handler to navigate to account page and trigger reload
+  const handleAccountClick = () => {
+    navigate('/account');
+    window.location.reload();
+  };
+
   return (
     <SyledHeader>
       <HeaderContainer>
@@ -72,7 +78,7 @@ function Header() {
             <DesktopButtons>
               {user ? (
                 <>
-                  <NavButton to="/account" $color="secondary">
+                  <NavButton to="#" $color="secondary" onClick={handleAccountClick}>
                     Account
                   </NavButton>
                   <Button onClick={() => mutateLogout()}>Log out</Button>


### PR DESCRIPTION
This PR adds a trigger for a page refresh to the `Header` whenever we navigate to the account page to avoid the display of outdated data. 